### PR TITLE
Fix bug for entirely empty chunks of rows

### DIFF
--- a/safedata_validator/field.py
+++ b/safedata_validator/field.py
@@ -2064,7 +2064,10 @@ class DatetimeField(BaseField):
 
             # Are the values internally consistent and consistent with
             # previously loaded data
-            if len(cell_type_set) > 1:
+            if len(cell_type_set) == 0:
+                # If data is empty skip consistency checking
+                return
+            elif len(cell_type_set) > 1:
                 self.consistent_class = False
                 return
             elif self.first_data_class_set is None:

--- a/safedata_validator/field.py
+++ b/safedata_validator/field.py
@@ -1952,7 +1952,10 @@ class TimeField(BaseField):
 
             # Are the values internally consistent and consistent with
             # previously loaded data
-            if len(cell_type_set) > 1:
+            if len(cell_type_set) == 0:
+                # If data is empty skip consistency checking
+                return
+            elif len(cell_type_set) > 1:
                 self.consistent_class = False
                 return
             elif self.first_data_class_set is None:

--- a/safedata_validator/field.py
+++ b/safedata_validator/field.py
@@ -2099,16 +2099,18 @@ class DatetimeField(BaseField):
                 if val.time() != midnight:
                     self.all_midnight = False
 
-        # Update range for extents
-        if self.min is None:
-            self.min = min(data)
-        else:
-            self.min = min([self.min] + data)
+        # Check that data isn't empty
+        if data:
+            # Update range for extents
+            if self.min is None:
+                self.min = min(data)
+            else:
+                self.min = min([self.min] + data)
 
-        if self.max is None:
-            self.max = min(data)
-        else:
-            self.max = max([self.max] + data)
+            if self.max is None:
+                self.max = min(data)
+            else:
+                self.max = max([self.max] + data)
 
     def report(self):
         """Report on field creation and data validation for date and datetime fields.

--- a/test/test_field.py
+++ b/test/test_field.py
@@ -1726,6 +1726,19 @@ def test_GeoField_validate_data(caplog, fixture_dataset, which, data, expected_l
             ],  # Different ISO8601 string formats
             ((INFO, "Checking field time"),),
         ),
+        (
+            [
+                ["11:12:13", "NA", "NA", "11:12:13", "11:12:13"],
+            ],
+            ((INFO, "Checking field time"), (WARNING, "2 / 5 values missing")),
+        ),
+        (
+            [
+                ["NA", "NA", "NA", "NA", "NA"],
+                ["11:12:13", "11:12:13", "11:12:13", "11:12:13", "11:12:13"],
+            ],
+            ((INFO, "Checking field time"), (WARNING, "5 / 10 values missing")),
+        ),
         # Bad inputs
         (
             [

--- a/test/test_field.py
+++ b/test/test_field.py
@@ -1832,6 +1832,33 @@ def test_TimeField_validate_data(caplog, data, expected_log):
             ((INFO, "Checking field datetimetest"),),
         ),
         (
+            "date",
+            [
+                [
+                    datetime(2022, 1, 6),
+                    datetime(2022, 1, 6),
+                    "NA",
+                    "NA",
+                    datetime(2022, 1, 6),
+                ],
+            ],
+            ((INFO, "Checking field datetimetest"), (WARNING, "2 / 5 values missing")),
+        ),
+        (
+            "date",
+            [
+                ["NA", "NA", "NA", "NA", "NA"],
+                [
+                    datetime(2022, 1, 6),
+                    datetime(2022, 1, 6),
+                    datetime(2022, 1, 6),
+                    datetime(2022, 1, 6),
+                    datetime(2022, 1, 6),
+                ],
+            ],
+            ((INFO, "Checking field datetimetest"), (WARNING, "5 / 10 values missing")),
+        ),
+        (
             "datetime",
             [
                 [


### PR DESCRIPTION
This PR adds a check that the set of valid dates isn't empty before attempting to use this to update the temporal bounds. This comes from a weird edge where a chunk of rows contains entirely "NA" and so every single entry is ignored

I haven't added a test to demonstrate that this works, if you think of an appropriate one let me know.