### PR TITLE
Pinning major version of `mkdocs` ecosystem packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
       day: "sunday"
       time: "03:00"
       timezone: "Europe/London"
+    # Ignore major version updates of mkdocs ecosystem packages
+    ignore:
+      - dependency-name: "mkdocs*"
+        update-types: ["version-update:semver-major"]
     groups:
       # Bundle updates in the pyproject.toml [tool.poetry.dependencies] section
       production-dependencies:


### PR DESCRIPTION
We agreed in #254 that the best approach to `mkdocs` is to refuse the major version updates, and to continue with pinned versions until such a time as the docs stop building. This is preferable to migrating now as the broader ecosystem is very much up in the air, and the current docs work for our purposes.

The mkdocs ecosystem packages are currently pinned to major versions. So all I needed to do was tell dependabot not to do major version updates for packages from this ecosystem.

Fixes #254