### PR TITLE
Fixes time for test_example_dataset test to keep test within embargo window

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -483,6 +483,21 @@ files = [
 ]
 
 [[package]]
+name = "freezegun"
+version = "1.5.5"
+description = "Let your Python tests travel through time"
+optional = false
+python-versions = ">=3.8"
+groups = ["test"]
+files = [
+    {file = "freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2"},
+    {file = "freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 description = "Copy your docs directly to the gh-pages branch."
@@ -1534,7 +1549,7 @@ version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main", "docs"]
+groups = ["main", "docs", "test"]
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
@@ -1912,7 +1927,7 @@ version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main", "docs"]
+groups = ["main", "docs", "test"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -2134,4 +2149,4 @@ bracex = ">=2.1.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "79a82d1cb5be7fd2d6a48e6bc6e7a3c9044d85111ee223916a15161a55f919cd"
+content-hash = "893f893594b015a2c0bfa997b5a5c8a5ea2bd4383366ef69127e930283a99d2d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ pyfakefs = ">=5.3,<7.0"
 pytest = ">=7,<10"
 pytest-cov = ">=3,<8"
 pytest-mock = "^3.7.0"
+freezegun = "^1.5.5"
 
 [tool.poetry.group.devenv.dependencies]
 mypy = ">=1.9,<3.0"

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -1,6 +1,7 @@
 """Test loading a dataworksheet from file."""
 
 import pytest
+from freezegun import freeze_time
 
 from safedata_validator.field import Dataset
 
@@ -25,6 +26,7 @@ def test_DataSet_load_from_file(fixture_resources, file_key, n_errors, n_taxa):
     assert len(ds.taxa.taxon_names) == n_taxa
 
 
+@freeze_time("2025-02-11")  # Freeze time to stay within dataset embargo window
 def test_example_dataset(fixture_resources):
     """Test that the example dataset we provide actually passes validation.
 


### PR DESCRIPTION
Adds `freezegun` as a (test) dependancy, which makes this freezing very straightforward 

Fixes #276 