### PR TITLE
Replaced links to template and example files in the docs with direct links to the files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.16
+    rev: v0.15.17
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/docs/data_managers/overview.md
+++ b/docs/data_managers/overview.md
@@ -61,16 +61,13 @@ The [usage recipes](using_safedata/overview.md) show how the tools are used.
 
 ## Example `safedata` format datasets
 
-<!-- The links here are hard coded to main, so if you've changed one of the files but 
-can't see the change in the docs that is why-->
 To help both data managers and data providers understand the `safedata` format we
 provide a number of resources. Firstly, a [template
-dataset](https://github.com/ImperialCollegeLondon/safedata_validator/raw/main/docs/data_providers/data_format/Template.xlsx)
-containing the required worksheets, labels and headers. Secondly, an [example
-dataset](https://github.com/ImperialCollegeLondon/safedata_validator/raw/main/docs/data_providers/data_format/Example.xlsx)
-demonstrating how to correctly format a wide variety of different types of data. You can
-also look at existing published datasets, such as those from the SAFE Project, to see
-how the format is used:
+dataset](../data_providers/data_format/Template.xlsx) containing the required
+worksheets, labels and headers. Secondly, an [example
+dataset](../data_providers/data_format/Example.xlsx) demonstrating how to correctly
+format a wide variety of different types of data. You can also look at existing
+published datasets, such as those from the SAFE Project, to see how the format is used:
 
 - [https://safeproject.net/datasets/view_datasets](https://safeproject.net/datasets/view_datasets)
 - [https://zenodo.org/communities/safe/](https://zenodo.org/communities/safe/)

--- a/docs/data_providers/data_format/overview.md
+++ b/docs/data_providers/data_format/overview.md
@@ -45,18 +45,14 @@ underscores to separate words.
 
 ### Spreadsheet Template and Examples
 
-<!-- The links here are hard coded to main, so if you've changed one of the files but 
-can't see the change in the docs that is why-->
-We provide a [spreadsheet
-template](https://github.com/ImperialCollegeLondon/safedata_validator/raw/main/docs/data_providers/data_format/Template.xlsx)
-containing the required worksheets, labels and headers.
+We provide a [spreadsheet template](Template.xlsx) containing the required worksheets,
+labels and headers.
 
-We also provide an [example
-file](https://github.com/ImperialCollegeLondon/safedata_validator/raw/main/docs/data_providers/data_format/Example.xlsx).
-This file is intended to demonstrate how to correctly format a wide variety of different
-types of data. The data in this spreadsheet mirrors the example data showed later in
-this section of the documentation. We would strongly recommend reading the relevant
-documentation before looking at the example file.
+We also provide an [example file](Example.xlsx). This file is intended to demonstrate
+how to correctly format a wide variety of different types of data. The data in this
+spreadsheet mirrors the example data showed later in this section of the documentation.
+We would strongly recommend reading the relevant documentation before looking at the
+example file.
 
 You can also look at existing published datasets, such as those from the SAFE Project,
 to see how the format is used:


### PR DESCRIPTION
Title. I'm actually unsure why I was even links to the GitHub website (instead of links to the files in the docs) in the first place?

Fixes #220 
